### PR TITLE
Fix Playwright HTML reporter behavior

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -14,7 +14,7 @@ export default defineConfig<ChromaticConfig>({
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : 3,
   reporter: [
-    ["html", { outputFolder: "./tests/e2e/__report__" }],
+    ["html", { outputFolder: "./tests/e2e/__report__", open: "never" }],
     ["line"],
     process.env.CI ? ["github"] : ["list"],
   ],


### PR DESCRIPTION
## Summary
- avoid opening HTML report after tests complete

## Testing
- `pnpm lint`
- `CI=1 pnpm test:e2e --reporter=line` *(fails: 72 failed)*

------
https://chatgpt.com/codex/tasks/task_e_688285a3e7bc832687b8f537915f21dc